### PR TITLE
enabling wired headset voice recognition

### DIFF
--- a/configs/audio/mixer_paths_0.xml
+++ b/configs/audio/mixer_paths_0.xml
@@ -1010,6 +1010,8 @@
 	</path>
 
 	<path name="voice-rec-headset-mic">
+		<ctl name="AIF1TX1 Input 1" value="LHPF1" />
+		<ctl name="AIF1TX2 Input 1" value="LHPF1" />
 		<ctl name="LHPF1 Input 1" value="IN2L"/>
 		<ctl name="Headset Mic Switch" value="1"/>
 		<path name="gain-recognition-headset-mic"/>


### PR DESCRIPTION
This change is required for 3.5 mm jack wired headset voice recognition to work on my SM-G930FD

I don't have other variants of the S7 flat nor S7 edge variants to test this however